### PR TITLE
[Recipe-Recommend] 레피시 추천 API 구현 및 rabbitMQ 설정 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    testImplementation 'org.springframework.amqp:spring-rabbit-test'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/api/IngredientController.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/api/IngredientController.java
@@ -49,4 +49,10 @@ public class IngredientController {
         ExpiredIngredientResponse response = ingredientService.getExpiredIngredients(request);
         return Responder.success(response);
     }
+
+    @PostMapping("/recipeRecommend")
+    public ResponseEntity<CheckAndSendMessageResponse> checkAndSendMessage(final @RequestBody CheckAndSendMessageRequest request) {
+        CheckAndSendMessageResponse response = ingredientService.checkAndSendMessage(request);
+        return Responder.success(response);
+    }
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorController.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorController.java
@@ -33,5 +33,4 @@ public class RefrigeratorController {
         RefrigeratorResponse response = refrigeratorService.deleteRefrigerator(request);
         return Responder.success(response);
     }
-    // TODO 레시피 추천 api 제작하기 ( 재료 있는 지에 대한 여부 확인 및 rabbitmq에 올리기 )
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/config/RabbitMQConfig.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/config/RabbitMQConfig.java
@@ -1,0 +1,47 @@
+package cloud.zipbob.ingredientsmanageservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.*;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfig {
+    private final RabbitMQProperties rabbitMQProperties;
+
+    @Bean
+    public Queue mainQueue() {
+        return QueueBuilder.durable(rabbitMQProperties.getQueueName())
+                .withArgument("x-message-ttl", 60000)
+                .withArgument("x-dead-letter-exchange", rabbitMQProperties.getDlx())
+                .withArgument("x-dead-letter-routing-key", rabbitMQProperties.getDlqRoutingKey())
+                .build();
+    }
+
+    @Bean
+    public Queue deadLetterQueue() {
+        return QueueBuilder.durable(rabbitMQProperties.getDlq()).build();
+    }
+
+    @Bean
+    public TopicExchange mainExchange() {
+        return new TopicExchange(rabbitMQProperties.getExchangeName());
+    }
+
+    @Bean
+    public TopicExchange deadLetterExchange() {
+        return new TopicExchange(rabbitMQProperties.getDlx());
+    }
+
+    @Bean
+    public Binding mainQueueBinding(@Qualifier("mainQueue") Queue mainQueue, @Qualifier("mainExchange") TopicExchange mainExchange) {
+        return BindingBuilder.bind(mainQueue).to(mainExchange).with(rabbitMQProperties.getRoutingKey());
+    }
+
+    @Bean
+    public Binding deadLetterQueueBinding(@Qualifier("deadLetterQueue") Queue deadLetterQueue, @Qualifier("deadLetterExchange") TopicExchange deadLetterExchange) {
+        return BindingBuilder.bind(deadLetterQueue).to(deadLetterExchange).with(rabbitMQProperties.getDlqRoutingKey());
+    }
+}

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/config/RabbitMQProperties.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/config/RabbitMQProperties.java
@@ -1,0 +1,24 @@
+package cloud.zipbob.ingredientsmanageservice.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Setter
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "rabbit")
+public class RabbitMQProperties {
+    private String queueName;
+
+    private String exchangeName;
+
+    private String routingKey;
+
+    private String dlq;
+
+    private String dlx;
+
+    private String dlqRoutingKey;
+}

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/exception/IngredientExceptionType.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/exception/IngredientExceptionType.java
@@ -4,7 +4,7 @@ import cloud.zipbob.ingredientsmanageservice.global.exception.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
 public enum IngredientExceptionType implements BaseExceptionType {
-    INGREDIENT_NOT_FOUND("I001", "해당 회원에게 재료가 존재하지 않습니다..", HttpStatus.NOT_FOUND),
+    INGREDIENT_NOT_FOUND("I001", "해당 회원에게 재료가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     INGREDIENT_NAME_ERROR("I002", "존재하지 않는 재료입니다.", HttpStatus.BAD_REQUEST),
     INGREDIENT_TYPE_ERROR("I003", "존재하지 않은 재료의 타입입니다.", HttpStatus.BAD_REQUEST),
     INGREDIENT_ALREADY_EXIST("I004", "이미 해당 회원의 냉장고에 재료가 존재합니다.", HttpStatus.CONFLICT);

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/repository/IngredientRepository.java
@@ -12,7 +12,5 @@ import java.util.Optional;
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findByRefrigeratorId(Long refrigeratorId);
 
-    List<Ingredient> findByType(IngredientType type);
-
     Optional<Ingredient> findByRefrigeratorIdAndType(Long refrigeratorId, IngredientType type);
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/request/CheckAndSendMessageRequest.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/request/CheckAndSendMessageRequest.java
@@ -1,0 +1,8 @@
+package cloud.zipbob.ingredientsmanageservice.domain.ingredient.request;
+
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
+
+import java.util.List;
+
+public record CheckAndSendMessageRequest(Long memberId, List<IngredientType> ingredients) {
+}

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/response/CheckAndSendMessageResponse.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/response/CheckAndSendMessageResponse.java
@@ -1,0 +1,20 @@
+package cloud.zipbob.ingredientsmanageservice.domain.ingredient.response;
+
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CheckAndSendMessageResponse {
+    private Long memberId;
+    private Long refrigeratorId;
+    private List<IngredientType> ingredients;
+    private final String message = "큐에 메시지가 정상적으로 등록되었습니다.";
+
+    public static CheckAndSendMessageResponse of(Long memberId, Long refrigeratorId, List<IngredientType> ingredients) {
+        return new CheckAndSendMessageResponse(memberId, refrigeratorId, ingredients);
+    }
+}

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientService.java
@@ -13,4 +13,7 @@ public interface IngredientService {
     ExpiredIngredientResponse getExpiredIngredients(ExpiredIngredientRequest request);
 
     GetIngredientsByTypeResponse getIngredientsByType(GetIngredientsByTypeRequest request);
+
+    // 냉장고 재료 여부 확인 및 Queue에 메시지 전공
+    CheckAndSendMessageResponse checkAndSendMessage(CheckAndSendMessageRequest request);
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/RabbitMQProducer.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/RabbitMQProducer.java
@@ -1,0 +1,35 @@
+package cloud.zipbob.ingredientsmanageservice.domain.ingredient.service;
+
+import cloud.zipbob.ingredientsmanageservice.config.RabbitMQProperties;
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RabbitMQProducer {
+    private final RabbitTemplate rabbitTemplate;
+    private final RabbitMQProperties rabbitMQProperties;
+    private final ObjectMapper objectMapper;
+
+    public void sendMessage(Long memberId, List<IngredientType> ingredients) {
+        try {
+            String message = objectMapper.writeValueAsString(
+                    Map.of("memberId", memberId, "ingredients", ingredients)
+            );
+            rabbitTemplate.convertAndSend(rabbitMQProperties.getExchangeName(), rabbitMQProperties.getRoutingKey(), message);
+            log.info("Message sent successfully to RabbitMQ. Exchange: {}, Message: {}",
+                    rabbitMQProperties.getExchangeName(), message);
+        } catch (Exception e) {
+            log.error("Failed to send message to RabbitMQ. Exchange: {}, Error: {}",
+                    rabbitMQProperties.getExchangeName(), e.getMessage());
+        }
+    }
+}

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/api/IngredientControllerTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/api/IngredientControllerTest.java
@@ -5,22 +5,27 @@ import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.UnitType;
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.repository.IngredientRepository;
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.request.*;
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.service.RabbitMQProducer;
 import cloud.zipbob.ingredientsmanageservice.domain.refrigerator.Refrigerator;
 import cloud.zipbob.ingredientsmanageservice.domain.refrigerator.repository.RefrigeratorRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -42,6 +47,9 @@ class IngredientControllerTest {
 
     @Autowired
     private IngredientRepository ingredientRepository;
+
+    @MockBean
+    private RabbitMQProducer rabbitMQProducer;
 
     private Long refrigeratorId;
 
@@ -93,6 +101,34 @@ class IngredientControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.refrigeratorId").value(refrigeratorId))
                 .andExpect(jsonPath("$.ingredientType").value("MILK"));
+    }
+
+    @Test
+    @DisplayName("재료 삭제 - 냉장고가 존재하지 않을 때 실패")
+    void deleteIngredient_ShouldReturnBadRequestForInvalidRefrigerator() throws Exception {
+        // Given
+        IngredientRequest request = new IngredientRequest(99L, IngredientType.MILK);
+
+        // When & Then
+        mockMvc.perform(delete("/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorMessage").value("해당 회원의 냉장고가 존재하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("재료 삭제 - 재료가 존재하지 않을 때 실패")
+    void deleteIngredient_ShouldReturnBadRequestForNonExistentIngredient() throws Exception {
+        // Given
+        IngredientRequest request = new IngredientRequest(10L, IngredientType.SALT);
+
+        // When & Then
+        mockMvc.perform(delete("/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorMessage").value("해당 회원에게 재료가 존재하지 않습니다."));
     }
 
     @Test
@@ -159,5 +195,57 @@ class IngredientControllerTest {
                 .andExpect(jsonPath("$.ingredients").value(org.hamcrest.Matchers.hasItem("EGG")))
                 .andExpect(jsonPath("$.ingredients").value(org.hamcrest.Matchers.hasItem("CHICKEN")))
                 .andExpect(jsonPath("$.ingredients").value(org.hamcrest.Matchers.not(org.hamcrest.Matchers.hasItem("SALT"))));
+    }
+
+    @Test
+    @DisplayName("재료 존재 여부 확인 및 RabbitMQ 메시지 전송 - 성공")
+    void checkAndSendMessage_ShouldReturnSuccess() throws Exception {
+        // Given: 냉장고에 재료 추가
+        IngredientAddRequest addRequest = new IngredientAddRequest(
+                10L,
+                IngredientType.MILK,
+                10,
+                UnitType.MILLILITER,
+                LocalDate.now().plusDays(7)
+        );
+
+        IngredientAddRequest addRequest2 = new IngredientAddRequest(
+                10L,
+                IngredientType.SALT,
+                10,
+                UnitType.PIECE,
+                LocalDate.now().plusDays(7)
+        );
+
+        mockMvc.perform(post("/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.refrigeratorId").value(refrigeratorId))
+                .andExpect(jsonPath("$.type").value("MILK"));
+
+        mockMvc.perform(post("/ingredients")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addRequest2)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.refrigeratorId").value(refrigeratorId))
+                .andExpect(jsonPath("$.type").value("SALT"));
+
+        CheckAndSendMessageRequest request = new CheckAndSendMessageRequest(
+                10L,
+                List.of(IngredientType.MILK, IngredientType.SALT)
+        );
+
+        // When & Then
+        mockMvc.perform(post("/ingredients/recipeRecommend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memberId").value(10L))
+                .andExpect(jsonPath("$.refrigeratorId").value(refrigeratorId))
+                .andExpect(jsonPath("$.message").value("큐에 메시지가 정상적으로 등록되었습니다."))
+                .andExpect(jsonPath("$.ingredients[0]").value("MILK"))
+                .andExpect(jsonPath("$.ingredients[1]").value("SALT"));
+        Mockito.verify(rabbitMQProducer, times(1)).sendMessage(10L, List.of(IngredientType.MILK, IngredientType.SALT));
     }
 }


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/recipe-recommend

## 📚 작업한 내용
### Recipe-Recommend
- 레시피 추천 api 구현을 완료하였습니다.
- 사용자의 id와 재료를 넣으면 냉장고 및 재료 여부 확인 후, 해당 메시지를 메시지 큐에 전송합니다.

### Test
- 통합 테스트를 통해 RabbitMQ 동작 테스트를 완료하였습니다.
- Line Converage 80% 이상을 유지하였습니다.

## ❗이슈 사항


## ⭐ 연관된 이슈
Close #3 

## 🤔 궁금한 점