### PR TITLE
[Enhancement JPA] N+1 문제 발생에 대한 해결 및 성능  테스트

### DIFF
--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/repository/IngredientRepository.java
@@ -2,6 +2,8 @@ package cloud.zipbob.ingredientsmanageservice.domain.ingredient.repository;
 
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.Ingredient;
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,9 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findByRefrigeratorId(Long refrigeratorId);
 
     Optional<Ingredient> findByRefrigeratorIdAndType(Long refrigeratorId, IngredientType type);
+
+    @NotNull
+//    @Query("select i from Ingredient i join fetch i.refrigerator")
+    @EntityGraph(attributePaths = {"refrigerator"})
+    List<Ingredient> findAll();
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/Refrigerator.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/Refrigerator.java
@@ -4,10 +4,12 @@ import cloud.zipbob.ingredientsmanageservice.domain.ingredient.Ingredient;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -25,9 +27,10 @@ public class Refrigerator {
     @Column(nullable = false)
     private Long memberId;
 
-    @OneToMany(mappedBy = "refrigerator", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "refrigerator", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 500)
     @JsonManagedReference
-    private List<Ingredient> ingredients;
+    private List<Ingredient> ingredients = new ArrayList<>();
 
     @CreatedDate
     LocalDateTime createdAt;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,6 @@ spring:
       uri: http://localhost:8888
       request-connect-timeout: 5000
       request-read-timeout: 5000
-
       fail-fast: false
       retry:
         max-attempts: 6

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/repository/RefrigeratorRepositoryTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/repository/RefrigeratorRepositoryTest.java
@@ -1,0 +1,101 @@
+package cloud.zipbob.ingredientsmanageservice.domain.refrigerator.repository;
+
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.Ingredient;
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.IngredientType;
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.UnitType;
+import cloud.zipbob.ingredientsmanageservice.domain.ingredient.repository.IngredientRepository;
+import cloud.zipbob.ingredientsmanageservice.domain.refrigerator.Refrigerator;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class RefrigeratorRepositoryTest {
+
+    @Autowired
+    private RefrigeratorRepository refrigeratorRepository;
+
+    @Autowired
+    private IngredientRepository ingredientRepository;
+
+    private Instant startTime;
+
+    @BeforeAll
+    @Transactional
+    public void setUp() {
+        for (int i = 1; i <= 100; i++) {
+            Refrigerator refrigerator = Refrigerator.builder()
+                    .memberId((long) i)
+                    .build();
+            refrigeratorRepository.save(refrigerator);
+
+            Ingredient ingredient1 = Ingredient.builder()
+                    .type(IngredientType.EGG)
+                    .quantity(10)
+                    .unitType(UnitType.COUNT)
+                    .expiredDate(LocalDate.now().plusDays(7))
+                    .refrigerator(refrigerator)
+                    .build();
+
+            Ingredient ingredient2 = Ingredient.builder()
+                    .type(IngredientType.MILK)
+                    .quantity(2)
+                    .unitType(UnitType.LITER)
+                    .expiredDate(LocalDate.now().plusDays(5))
+                    .refrigerator(refrigerator)
+                    .build();
+
+            ingredientRepository.saveAll(List.of(ingredient1, ingredient2));
+        }
+    }
+
+    @BeforeEach
+    public void startTimer() {
+        startTime = Instant.now();
+    }
+
+    @AfterEach
+    public void stopTimer() {
+        Instant endTime = Instant.now();
+        long executionTime = endTime.toEpochMilli() - startTime.toEpochMilli();
+        System.out.println("테스트 실행 시간: " + executionTime + "ms");
+    }
+
+    @Test
+    @DisplayName("냉장고 조회시, n+1문제 발생 확인")
+    public void testNPlusOneProblemInRefrigerators() {
+        System.out.println("-------- 냉장고 전체 조회 요청 --------");
+        List<Refrigerator> refrigerators = refrigeratorRepository.findAll();
+        System.out.println("-------- 냉장고 조회 완료 --------");
+
+        refrigerators.forEach(refrigerator -> {
+            System.out.println("Refrigerator ID: " + refrigerator.getId());
+            refrigerator.getIngredients().forEach(ingredient -> {
+                System.out.println("  Ingredient Type: " + ingredient.getType() +
+                        ", Quantity: " + ingredient.getQuantity() +
+                        ", Unit: " + ingredient.getUnitType());
+            });
+        });
+    }
+
+    @Test
+    @DisplayName("재료 조회시, n+1문제 발생 확인")
+    public void testNPlusOneProblemInIngredients() {
+        System.out.println("-------- 재료 전체 조회 요청 --------");
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        System.out.println("-------- 재료 조회 완료 --------");
+
+        ingredients.forEach(ingredient -> {
+            System.out.println("Ingredients ID: " + ingredient.getId());
+        });
+    }
+}


### PR DESCRIPTION
## 🌲 작업한 브랜치
- enhance/n+1

## 📚 작업한 내용
### JPA N+1
- 냉장고 및 재료 전체를 조회하는 과정에서 추가 쿼리가 발생하는 n+1문제가 발생하여 이를 해결하기 위해 다음과 같은 방법을 적용하였습니다.
  - EntityGraph를 활용하여 LeftJoin을 이루어 데이터를 한번에 가져올 수 있도록 구성하였습니다.
  - BatchSize를 지정하여 데이터를 배치 사이즈 만큼 한번에 가져올 수 있도록 하였습니다. 현재는 500으로 설정하였지만 추후 데이터가 늘어날 경우 사이즈 조정이 필요합니다.

### Test
- 성능 비교 테스트를 위해 10000개의 데이터를 넣어 테스트를 진행해보았습니다. (배포시 테스트 시간이 오래걸릴 것을 감안하여 현재는 100개로 낮춘 상황입니다.)
  - @OneToMany 관계로 연관된 데이터가 조회되는 경우, 3526ms -> 540ms 로 약 85%의 성능 개선을 이루었습니다.
  - @ManyToOne 관계로 연관된 데이터가 조회되는 경우, 3383ms -> 206ms 로 약 94%의 성능 개선을 이루었습니다.

[블로그 정리 내용](https://velog.io/@lord/JPA-N1-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0-%EB%B0%8F-%EC%84%B1%EB%8A%A5-%EB%B9%84%EA%B5%90%ED%95%98%EA%B8%B0)

## ❗이슈 사항

## ⭐ 연관된 이슈

## 🤔 궁금한 점