### PR TITLE
[MemberId-Verification] 멤버 id를 사용한 검증 로직 추가

### DIFF
--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/api/IngredientController.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/api/IngredientController.java
@@ -17,20 +17,20 @@ public class IngredientController {
     private final IngredientService ingredientService;
 
     @PostMapping("")
-    public ResponseEntity<IngredientAddResponse> addIngredient(final @RequestBody IngredientAddRequest request) {
-        IngredientAddResponse response = ingredientService.addIngredient(request);
+    public ResponseEntity<IngredientAddResponse> addIngredient(final @RequestBody IngredientAddRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        IngredientAddResponse response = ingredientService.addIngredient(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
     @DeleteMapping("")
-    public ResponseEntity<IngredientDeleteResponse> deleteIngredient(final @RequestBody IngredientRequest request) {
-        IngredientDeleteResponse response = ingredientService.deleteIngredient(request);
+    public ResponseEntity<IngredientDeleteResponse> deleteIngredient(final @RequestBody IngredientRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        IngredientDeleteResponse response = ingredientService.deleteIngredient(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
     @PatchMapping("/update")
-    public ResponseEntity<UpdateQuantityResponse> updateQuantity(final @RequestBody UpdateQuantityRequest request) {
-        UpdateQuantityResponse response = ingredientService.updateQuantity(request);
+    public ResponseEntity<UpdateQuantityResponse> updateQuantity(final @RequestBody UpdateQuantityRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        UpdateQuantityResponse response = ingredientService.updateQuantity(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
@@ -45,14 +45,14 @@ public class IngredientController {
     }
 
     @GetMapping("/expired")
-    public ResponseEntity<ExpiredIngredientResponse> getExpiredIngredients(final @RequestBody ExpiredIngredientRequest request) {
-        ExpiredIngredientResponse response = ingredientService.getExpiredIngredients(request);
+    public ResponseEntity<ExpiredIngredientResponse> getExpiredIngredients(final @RequestBody ExpiredIngredientRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        ExpiredIngredientResponse response = ingredientService.getExpiredIngredients(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
     @PostMapping("/recipeRecommend")
-    public ResponseEntity<CheckAndSendMessageResponse> checkAndSendMessage(final @RequestBody CheckAndSendMessageRequest request) {
-        CheckAndSendMessageResponse response = ingredientService.checkAndSendMessage(request);
+    public ResponseEntity<CheckAndSendMessageResponse> checkAndSendMessage(final @RequestBody CheckAndSendMessageRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        CheckAndSendMessageResponse response = ingredientService.checkAndSendMessage(request, authenticatedMemberId);
         return Responder.success(response);
     }
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorController.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorController.java
@@ -17,20 +17,20 @@ public class RefrigeratorController {
     private final RefrigeratorService refrigeratorService;
 
     @PostMapping("")
-    public ResponseEntity<RefrigeratorResponse> createRefrigerator(final @RequestBody RefrigeratorCreateRequest request) {
-        RefrigeratorResponse response = refrigeratorService.createRefrigerator(request);
+    public ResponseEntity<RefrigeratorResponse> createRefrigerator(final @RequestBody RefrigeratorCreateRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        RefrigeratorResponse response = refrigeratorService.createRefrigerator(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
     @GetMapping("")
-    public ResponseEntity<RefrigeratorWithIngredientsResponse> getRefrigerator(final @RequestBody RefrigeratorRequest request) {
-        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request);
+    public ResponseEntity<RefrigeratorWithIngredientsResponse> getRefrigerator(final @RequestBody RefrigeratorRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request, authenticatedMemberId);
         return Responder.success(response);
     }
 
     @DeleteMapping("")
-    public ResponseEntity<RefrigeratorResponse> deleteRefrigerator(final @RequestBody RefrigeratorRequest request) {
-        RefrigeratorResponse response = refrigeratorService.deleteRefrigerator(request);
+    public ResponseEntity<RefrigeratorResponse> deleteRefrigerator(final @RequestBody RefrigeratorRequest request, @RequestHeader("X-Member-Id") Long authenticatedMemberId) {
+        RefrigeratorResponse response = refrigeratorService.deleteRefrigerator(request, authenticatedMemberId);
         return Responder.success(response);
     }
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientService.java
@@ -4,16 +4,17 @@ import cloud.zipbob.ingredientsmanageservice.domain.ingredient.request.*;
 import cloud.zipbob.ingredientsmanageservice.domain.ingredient.response.*;
 
 public interface IngredientService {
-    IngredientAddResponse addIngredient(IngredientAddRequest request);
 
-    IngredientDeleteResponse deleteIngredient(IngredientRequest request);
+    IngredientAddResponse addIngredient(IngredientAddRequest request, Long authenticatedMemberId);
 
-    UpdateQuantityResponse updateQuantity(UpdateQuantityRequest request);
+    IngredientDeleteResponse deleteIngredient(IngredientRequest request, Long authenticatedMemberId);
 
-    ExpiredIngredientResponse getExpiredIngredients(ExpiredIngredientRequest request);
+    UpdateQuantityResponse updateQuantity(UpdateQuantityRequest request, Long authenticatedMemberId);
+
+    ExpiredIngredientResponse getExpiredIngredients(ExpiredIngredientRequest request, Long authenticatedMemberId);
 
     GetIngredientsByTypeResponse getIngredientsByType(GetIngredientsByTypeRequest request);
 
     // 냉장고 재료 여부 확인 및 Queue에 메시지 전공
-    CheckAndSendMessageResponse checkAndSendMessage(CheckAndSendMessageRequest request);
+    CheckAndSendMessageResponse checkAndSendMessage(CheckAndSendMessageRequest request, Long authenticatedMemberId);
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/service/RefrigeratorService.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/service/RefrigeratorService.java
@@ -6,9 +6,9 @@ import cloud.zipbob.ingredientsmanageservice.domain.refrigerator.response.Refrig
 import cloud.zipbob.ingredientsmanageservice.domain.refrigerator.response.RefrigeratorWithIngredientsResponse;
 
 public interface RefrigeratorService {
-    RefrigeratorResponse createRefrigerator(RefrigeratorCreateRequest request);
+    RefrigeratorResponse createRefrigerator(RefrigeratorCreateRequest request, Long authenticatedMemberId);
 
-    RefrigeratorResponse deleteRefrigerator(RefrigeratorRequest request);
+    RefrigeratorResponse deleteRefrigerator(RefrigeratorRequest request, Long authenticatedMemberId);
 
-    RefrigeratorWithIngredientsResponse getRefrigerator(RefrigeratorRequest request);
+    RefrigeratorWithIngredientsResponse getRefrigerator(RefrigeratorRequest request, Long authenticatedMemberId);
 }

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/global/exception/CustomAuthenticationException.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/global/exception/CustomAuthenticationException.java
@@ -1,0 +1,14 @@
+package cloud.zipbob.ingredientsmanageservice.global.exception;
+
+public class CustomAuthenticationException extends BaseException {
+    private final BaseExceptionType exceptionType;
+
+    public CustomAuthenticationException(BaseExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/cloud/zipbob/ingredientsmanageservice/global/exception/CustomAuthenticationExceptionType.java
+++ b/src/main/java/cloud/zipbob/ingredientsmanageservice/global/exception/CustomAuthenticationExceptionType.java
@@ -1,0 +1,32 @@
+package cloud.zipbob.ingredientsmanageservice.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum CustomAuthenticationExceptionType implements BaseExceptionType {
+    AUTHENTICATION_DENIED("AT001", "올바르지 않은 사용자의 요청입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String errorCode;
+    private final String errorMessage;
+    private final HttpStatus httpStatus;
+
+    CustomAuthenticationExceptionType(String errorCode, String errorMessage, HttpStatus httpStatus) {
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return this.errorMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/api/IngredientControllerTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/api/IngredientControllerTest.java
@@ -71,6 +71,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(post("/ingredients")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -96,6 +97,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(delete("/ingredients")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -111,6 +113,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(delete("/ingredients")
+                        .header("X-Member-Id", 99L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -125,6 +128,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(delete("/ingredients")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -148,6 +152,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(patch("/ingredients/update")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -173,6 +178,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(get("/ingredients/expired")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -218,6 +224,7 @@ class IngredientControllerTest {
         );
 
         mockMvc.perform(post("/ingredients")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(addRequest)))
                 .andExpect(status().isOk())
@@ -225,6 +232,7 @@ class IngredientControllerTest {
                 .andExpect(jsonPath("$.type").value("MILK"));
 
         mockMvc.perform(post("/ingredients")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(addRequest2)))
                 .andExpect(status().isOk())
@@ -238,6 +246,7 @@ class IngredientControllerTest {
 
         // When & Then
         mockMvc.perform(post("/ingredients/recipeRecommend")
+                        .header("X-Member-Id", 10L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorControllerTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/api/RefrigeratorControllerTest.java
@@ -73,6 +73,7 @@ class RefrigeratorControllerTest {
         RefrigeratorCreateRequest request = new RefrigeratorCreateRequest(3L);
 
         mockMvc.perform(post("/refrigerators")
+                        .header("X-Member-Id", 3L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -85,6 +86,7 @@ class RefrigeratorControllerTest {
         RefrigeratorCreateRequest request = new RefrigeratorCreateRequest(memberIdWithIngredients);
 
         mockMvc.perform(post("/refrigerators")
+                        .header("X-Member-Id", memberIdWithIngredients)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -97,6 +99,7 @@ class RefrigeratorControllerTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithIngredients);
 
         mockMvc.perform(get("/refrigerators")
+                        .header("X-Member-Id", memberIdWithIngredients)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -110,6 +113,7 @@ class RefrigeratorControllerTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithoutIngredients);
 
         mockMvc.perform(get("/refrigerators")
+                        .header("X-Member-Id", memberIdWithoutIngredients)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -123,6 +127,7 @@ class RefrigeratorControllerTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithoutIngredients);
 
         mockMvc.perform(delete("/refrigerators")
+                        .header("X-Member-Id", memberIdWithoutIngredients)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -130,6 +135,7 @@ class RefrigeratorControllerTest {
 
         // 삭제 후 확인
         mockMvc.perform(get("/refrigerators")
+                        .header("X-Member-Id", memberIdWithoutIngredients)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound());
@@ -141,6 +147,7 @@ class RefrigeratorControllerTest {
         RefrigeratorRequest request = new RefrigeratorRequest(999L);
 
         mockMvc.perform(get("/refrigerators")
+                        .header("X-Member-Id", 999L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -153,6 +160,7 @@ class RefrigeratorControllerTest {
         RefrigeratorRequest request = new RefrigeratorRequest(999L);
 
         mockMvc.perform(delete("/refrigerators")
+                        .header("X-Member-Id", 999L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientServiceImplTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/ingredient/service/IngredientServiceImplTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,12 +48,12 @@ class IngredientServiceImplTest {
 
     @Test
     @DisplayName("재료 추가 - 냉장고에 새로운 재료를 추가하면 저장")
-    void addIngredient_ShouldAddIngredientToRefrigerator() {
+    void addIngredient_ShouldAddIngredientToRefrigerator() throws AccessDeniedException {
         // Given
         IngredientAddRequest request = new IngredientAddRequest(5L, IngredientType.EGG, 10, UnitType.PIECE, LocalDate.now().plusDays(7));
 
         // When
-        IngredientAddResponse response = ingredientService.addIngredient(request);
+        IngredientAddResponse response = ingredientService.addIngredient(request, 5L);
 
         // Then
         assertNotNull(response);
@@ -77,7 +78,7 @@ class IngredientServiceImplTest {
         IngredientRequest request = new IngredientRequest(5L, IngredientType.MILK);
 
         // When
-        IngredientDeleteResponse response = ingredientService.deleteIngredient(request);
+        IngredientDeleteResponse response = ingredientService.deleteIngredient(request, 5L);
 
         // Then
         assertNotNull(response);
@@ -102,7 +103,7 @@ class IngredientServiceImplTest {
         UpdateQuantityRequest request = new UpdateQuantityRequest(5L, IngredientType.CARROT, 10);
 
         // When
-        UpdateQuantityResponse response = ingredientService.updateQuantity(request);
+        UpdateQuantityResponse response = ingredientService.updateQuantity(request, 5L);
 
         // Then
         assertNotNull(response);
@@ -136,7 +137,7 @@ class IngredientServiceImplTest {
         ExpiredIngredientRequest request = new ExpiredIngredientRequest(5L);
 
         // When
-        ExpiredIngredientResponse response = ingredientService.getExpiredIngredients(request);
+        ExpiredIngredientResponse response = ingredientService.getExpiredIngredients(request, 5L);
 
         // Then
         assertNotNull(response);

--- a/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/service/RefrigeratorServiceImplTest.java
+++ b/src/test/java/cloud/zipbob/ingredientsmanageservice/domain/refrigerator/service/RefrigeratorServiceImplTest.java
@@ -71,7 +71,7 @@ class RefrigeratorServiceImplTest {
         RefrigeratorCreateRequest request = new RefrigeratorCreateRequest(3L);
 
         // When
-        RefrigeratorResponse response = refrigeratorService.createRefrigerator(request);
+        RefrigeratorResponse response = refrigeratorService.createRefrigerator(request, 3L);
 
         // Then
         Refrigerator saved = refrigeratorRepository.findById(response.getRefrigeratorId()).orElse(null);
@@ -87,7 +87,7 @@ class RefrigeratorServiceImplTest {
 
         // When & Then
         RefrigeratorException exception = assertThrows(RefrigeratorException.class, () ->
-                refrigeratorService.createRefrigerator(request)
+                refrigeratorService.createRefrigerator(request, 1L)
         );
 
         assertEquals(RefrigeratorExceptionType.ALREADY_EXIST_REFRIGERATOR, exception.getExceptionType());
@@ -100,7 +100,7 @@ class RefrigeratorServiceImplTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithIngredients);
 
         // When
-        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request);
+        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request, 1L);
 
         // Then
         assertEquals(memberIdWithIngredients, response.getMemberId());
@@ -116,7 +116,7 @@ class RefrigeratorServiceImplTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithoutIngredients);
 
         // When
-        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request);
+        RefrigeratorWithIngredientsResponse response = refrigeratorService.getRefrigerator(request, 2L);
 
         // Then
         assertEquals(memberIdWithoutIngredients, response.getMemberId());
@@ -131,7 +131,7 @@ class RefrigeratorServiceImplTest {
         RefrigeratorRequest request = new RefrigeratorRequest(memberIdWithoutIngredients);
 
         // When
-        RefrigeratorResponse response = refrigeratorService.deleteRefrigerator(request);
+        RefrigeratorResponse response = refrigeratorService.deleteRefrigerator(request, 2L);
 
         // Then
         assertFalse(refrigeratorRepository.existsById(response.getRefrigeratorId()));
@@ -146,7 +146,7 @@ class RefrigeratorServiceImplTest {
 
         // When & Then
         RefrigeratorException exception = assertThrows(RefrigeratorException.class, () ->
-                refrigeratorService.getRefrigerator(request)
+                refrigeratorService.getRefrigerator(request, 999L)
         );
 
         assertEquals(RefrigeratorExceptionType.REFRIGERATOR_NOT_FOUND, exception.getExceptionType());
@@ -160,7 +160,7 @@ class RefrigeratorServiceImplTest {
 
         // When & Then
         RefrigeratorException exception = assertThrows(RefrigeratorException.class, () ->
-                refrigeratorService.deleteRefrigerator(request)
+                refrigeratorService.deleteRefrigerator(request, 999L)
         );
 
         assertEquals(RefrigeratorExceptionType.REFRIGERATOR_NOT_FOUND, exception.getExceptionType());


### PR DESCRIPTION
## 🌲 작업한 브랜치
- feature/memberId-verification

## 📚 작업한 내용
### Verification by MemberId
- 엣지서비스로부터 넘어온 인증된 memberId를 사용하여 내부 로직에서 사용하는 memberId와 비교하여 사용자에 대한 검증 로직을 추가하였습니다.
- 테스트도 모두 변경사항을 반영하여 수정하였습니다.

## ❗이슈 사항

## ⭐ 연관된 이슈
Close #8 

## 🤔 궁금한 점